### PR TITLE
Always use two column layout

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -78,12 +78,14 @@ export default class App extends Component {
               />
             ))}
           </div>
-          <div className="viewer sticky" style={{top: 0, marginTop: "6.5rem"}}>
+          <div className="viewer sticky">
+            <div style={{top: 0, marginTop: "6.5rem", width: "520px", height: "520px" }}>
             <PhotoViewer
               url={url}
               alt={imageViewer.alt}
               caption={imageViewer.caption}
             />
+            </div>
         </div>
       </div>
     );

--- a/src/components/post/post.js
+++ b/src/components/post/post.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { renderMark } from '../../marks/marks.js';
 import { Link } from 'react-router-dom';
 import { Editor } from 'slate-react';
-import Gallery from '../photo/gallery.js';
 import PhotoViewer from "../photo/photo-viewer.js";
 
 export default class Post extends Component {
@@ -19,7 +18,7 @@ export default class Post extends Component {
   }
 
   renderFullPost() {
-    const { post, setImage, readOnly, imageViewer } = this.props;
+    const { post, setImage, readOnly } = this.props;
     return (
         <Editor
           value={post}
@@ -62,11 +61,13 @@ export default class Post extends Component {
           )}
           {!this.props.summaryView && (
             <div className="viewer sticky mt1" style={{top:0}}>
-              <PhotoViewer
-                url={url}
-                alt={imageViewer.alt}
-                caption={imageViewer.caption}
-              />
+              <div style={{width: "520px", height: "520px" }}>
+                <PhotoViewer
+                  url={url}
+                  alt={imageViewer.alt}
+                  caption={imageViewer.caption}
+                />
+              </div>
             </div>
             )}
           </div>

--- a/src/marks/ImageMark.js
+++ b/src/marks/ImageMark.js
@@ -2,9 +2,6 @@ import React, { Component } from 'react';
 
 import Photo from '../components/photo/photo';
 
-const MED_IMG = 'med';
-const LG_IMG = 'lg';
-
 export default class ImageMark extends Component {
   constructor() {
     super();


### PR DESCRIPTION
Reserve space for the image viewer, even if no image url is set.
This keeps the text from jumping around when the image viewer is added
to the DOM.